### PR TITLE
Add payload to message

### DIFF
--- a/app/components/rec-button.js
+++ b/app/components/rec-button.js
@@ -5,7 +5,7 @@ export default Component.extend({
   zmq: service('zmq-client'),
   actions: {
     toggleRec(device) {
-      let message = {message_type: 'post', message: 'sense_on'}
+      let message = {message_type: 'post', message: 'sense_on', payload: {}}
       if (device.get('recording')) message["message"] = 'sense_off'
 
       const result = this.zmq.request(message)


### PR DESCRIPTION
The JSON schema requires payloads to be defined for the `sense_on` and `sense_off` messages. This commit adds that payload. Nothing needs to be in it, it just needs to exist.