### PR TITLE
Fix quit message

### DIFF
--- a/app/components/quit-button.js
+++ b/app/components/quit-button.js
@@ -7,7 +7,7 @@ export default Component.extend({
   actions: {
     quit() {
       // Send quit message to summit-interface
-      const message = {message_type: 'post', message: 'quit'}
+      const message = {message_type: 'post', message: 'quit', payload: {}}
       this.zmq.request(message)
 
       // Close electron window


### PR DESCRIPTION
Like `sense_on` and `sense_off`, `quit` needs a payload as well.