### PR TITLE
Expand timeout window to 30 sec

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -29,6 +29,7 @@ export default Route.extend(I18nMixin, {
       const deviceStatus = this.zmq.request(statusMessage)
       deviceStatus
         .then((response) => {
+          console.log(response);
           if (response['payload']['success']) {
             device.set('error', '')
             device.set('stimulation_voltage', response['payload']['stim_on'])
@@ -41,7 +42,7 @@ export default Route.extend(I18nMixin, {
     }
     let device = model.store.peekRecord('device', 1)
     getStatus(device)
-    window.setInterval(getStatus, 10000, device)
+    window.setInterval(getStatus, 30000, device)
 
   },
 

--- a/electron-app/src/index.js
+++ b/electron-app/src/index.js
@@ -86,7 +86,15 @@ ipcMain.on('request', (event, args) => {
       event.reply('response', res)
     })
     .catch((err) => {
-      event.reply('response', error_message)
+      event.reply('response', JSON.stringify({
+        message_type: "result",
+        message: "error",
+        payload: {
+          status: false,
+          error_code: -1,
+          error_message: err
+        }
+      }));
       console.log("Error caught in return ipc message from Summit API")
       console.log(err)
     })

--- a/electron-app/src/zmq-client.js
+++ b/electron-app/src/zmq-client.js
@@ -14,6 +14,9 @@ function race(promise, timeout, error) {
     promise.then((value) => {
       clearTimeout(timer)
       return value
+    }).catch((err) => {
+      console.log(err)
+      throw err
     })
   ])
 }
@@ -40,13 +43,13 @@ async function sendAndReceive(message) {
   const error_string = JSON.stringify(error_message)
 
   try {
-    const res = await race(sock.receive(), 10000, error_string)
+    const res = await race(sock.receive(), 30000, error_string)
     str = res.toString()
     return str
   } catch (err) {
     console.log("Error caught in zmq communication with Summit API")
     console.log(err)
-    throw(err)
+    throw err
   }
 }
 


### PR DESCRIPTION
Sometimes the CTM take up to 30 seconds to create a response to a `device_info` query. That was way larger than 10 seconds, and it would cause the request socket to get out of sync with the backend. This simple workaround seems to alleviate some of that stress